### PR TITLE
Add policy violation event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## [1.1.1] - 2018-01.19
+## [1.2.0] - 2018-02-01
+### Added
+- ability to handle `messaging_policy_enforcement` webhook from Facebook
+  - https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_policy_enforcement 
+
+## [1.1.1] - 2018-01-19
 ### Added
 - `prior_message` method added to common incoming messages.
   - See step 7, ["Handle the user response" in Facebook docs](https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin)

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -20,6 +20,7 @@ module Facebook
         referral
         message_echo
         payment
+        messaging_policy_enforcement
       ].freeze
 
       class << self

--- a/lib/facebook/messenger/bot.rb
+++ b/lib/facebook/messenger/bot.rb
@@ -20,7 +20,7 @@ module Facebook
         referral
         message_echo
         payment
-        messaging_policy_enforcement
+        policy-enforcement
       ].freeze
 
       class << self

--- a/lib/facebook/messenger/incoming.rb
+++ b/lib/facebook/messenger/incoming.rb
@@ -9,6 +9,7 @@ require 'facebook/messenger/incoming/read'
 require 'facebook/messenger/incoming/account_linking'
 require 'facebook/messenger/incoming/referral'
 require 'facebook/messenger/incoming/payment'
+require 'facebook/messenger/incoming/policy_enforcement'
 
 module Facebook
   module Messenger
@@ -25,7 +26,8 @@ module Facebook
         'referral' => Referral,
         'message_echo' => MessageEcho,
         'message_request' => MessageRequest,
-        'payment' => Payment
+        'payment' => Payment,
+        'policy-enforcement' => PolicyEnforcement
       }.freeze
 
       # Parse the given payload.

--- a/lib/facebook/messenger/incoming/policy_enforcement.rb
+++ b/lib/facebook/messenger/incoming/policy_enforcement.rb
@@ -1,0 +1,17 @@
+module Facebook
+  module Messenger
+    module Incoming
+      class PolicyEnforcement
+        include Facebook::Messenger::Incoming::Common
+
+        def action
+          @messaging['policy-enforcement']['action']
+        end
+
+        def reason
+          @messaging['policy-enforcement']['reason']
+        end
+      end
+    end
+  end
+end

--- a/lib/facebook/messenger/version.rb
+++ b/lib/facebook/messenger/version.rb
@@ -1,5 +1,5 @@
 module Facebook
   module Messenger
-    VERSION = '1.1.1'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end


### PR DESCRIPTION
Allow end-users to manage incoming violation webhooks.

https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messaging_policy_enforcement